### PR TITLE
Modified/alternative xlsx streamer API using "zip" package + fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@ samples
 result
 result-doc
 *.lock
+*.o
+*.hi
+*.prof
+*.aux
+*.hp
+*.ps
+.envrc
+.direnv

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ result-doc
 *.ps
 .envrc
 .direnv
+cabal.project.local

--- a/benchmarks/Stream.hs
+++ b/benchmarks/Stream.hs
@@ -21,7 +21,7 @@ main = do
   runXlsxM "data/simple.xlsx" $ do
     WorkbookInfo sheets <- getWorkbookInfo
     forM_ (Map.keys sheets) $ \sheetNum -> do
-      readSheet UseHexpat sheetNum $ \x -> modifyIORef' ref (`DL.snoc` x)
+      readSheet sheetNum $ \x -> modifyIORef' ref (`DL.snoc` x)
   let nonStreamingSource = do
         gathered <- liftIO $ readIORef ref
         yieldMany $ DL.toList gathered

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,6 +1,0 @@
-optimization: 2
-ignore-project: False
-library-profiling: False 
-executable-profiling: False 
-tests: True
-benchmarks: True

--- a/countrows/Main.hs
+++ b/countrows/Main.hs
@@ -8,7 +8,7 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-    (fname:arg:_) -> do
-      mNum <- runXlsxM fname $ countRowsInSheet 1 (read arg)
+    (fname:_) -> do
+      mNum <- runXlsxM fname $ countRowsInSheet 1
       putStrLn $ show mNum
-    _ -> error "usage: count-rows FILE {True(useHexpat)|False(useXmlConduit)}"
+    _ -> error "usage: count-rows FILE"

--- a/countrows/Main.hs
+++ b/countrows/Main.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Codec.Xlsx.Parser.Stream
+import System.Environment
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    (fname:arg:_) -> do
+      mNum <- runXlsxM fname $ countRowsInSheet 1 (read arg)
+      putStrLn $ show mNum
+    _ -> error "usage: count-rows FILE {True(useHexpat)|False(useXmlConduit)}"

--- a/default-flake.nix
+++ b/default-flake.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = ./.;
+}).defaultNix

--- a/default-nonflake.nix
+++ b/default-nonflake.nix
@@ -1,0 +1,26 @@
+let
+  rev = "07ca3a021f05d6ff46bbd03c418b418abb781279"; # first 21.05 release
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+  compiler = "ghc884";
+  pkgs = import (builtins.fetchTarball url) {
+    config = {
+      packageOverrides = pkgs_super: {
+        haskell = pkgs_super.haskell // {
+          packages = pkgs_super.haskell.packages // {
+            "${compiler}" = pkgs_super.haskell.packages."${compiler}".override {
+              overrides = self: super: {
+                mkDerivation = args: super.mkDerivation (args // {
+                  enableLibraryProfiling = true;
+                });
+                # libxml-sax = pkgs_super.haskell.lib.dontHaddock (pkgs_super.haskell.lib.dontCheck (
+                #   self.callCabal2nix "libxml-sax" ../libxml-sax {}));
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  hpkgs = pkgs.haskell.packages."${compiler}";
+in pkgs.haskell.lib.dontCheck (hpkgs.callCabal2nix "xlsx" ./. {})

--- a/shell-flake.nix
+++ b/shell-flake.nix
@@ -1,0 +1,1 @@
+(import ./.).devShell."${builtins.currentSystem}"

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,2 @@
-(import ./.).devShell."${builtins.currentSystem}"
+(import ./default-nonflake.nix).env # not flake-based
+# (import ./.).devShell."${builtins.currentSystem}" # flake-based

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TupleSections             #-}
@@ -16,7 +17,7 @@ module Codec.Xlsx.Parser
   , Parser
   ) where
 
-import qualified Codec.Archive.Zip as Zip
+import qualified "zip-archive" Codec.Archive.Zip as Zip
 import Control.Applicative
 import Control.Arrow (left)
 import Control.Error.Safe (headErr)

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -145,7 +145,6 @@ module Codec.Xlsx.Parser.Stream
   , XlsxM
   , runXlsxM
   , getSheetSource
-  , getSheetXmlSource
   , getOrParseSharedStrings
   , countRowsInSheet
 
@@ -450,12 +449,9 @@ getOrParseSharedStrings = do
       liftIO $ writeIORef sharedStringsRef $ Just sharedStrings
       pure sharedStrings
 
--- | If the given sheet number exists, returns Just a conduit source
+-- If the given sheet number exists, returns Just a conduit source
 -- of the stream of XML events (using the xml-conduit packgae) in a
 -- particular sheet. Returns Nothing when the sheet doesn't exist.
---
--- This is a lower level API for full control over the XML in a given
--- sheet. For a higher level API, see 'getSheetSource'.
 getSheetXmlSource ::
   (PrimMonad m, MonadIO m, MonadThrow m, C.MonadResource m) =>
   -- | The sheet number

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -427,7 +427,14 @@ parseFileC = await >>= parseEventLoop
     parseEventLoop = \case
       Nothing -> pure ()
       Just evt -> use fileLens >>= \case
-        Sheet name -> parseSheetC evt name
+        Sheet name -> do
+          prevSheetName <- use ps_sheet_name
+          when (prevSheetName /= name) $
+            -- TODO: this is the last part of the file name containing
+            -- a particular sheet, not the actual sheet name as it
+            -- appears in the Excel UI.
+            ps_sheet_name .= name
+          parseSheetC evt name
         _          -> await >>= parseEventLoop
 
 -- | Parse sheet

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -18,14 +18,6 @@
 {-# LANGUAGE StrictData          #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-full-laziness #-}
-
--- This module must be compiled with -fno-full-laziness, otherwise
--- over-aggressive caching by GHC during -O2 builds mean that the
--- first call to `getEntrySource <sheetNum>` will be cached, and all
--- subsequent calls (_even_ those with a different sheet number) will
--- return the original sheet source.
-
 -- |
 -- Module      : Codex.Xlsx.Parser.Stream
 -- Description : Stream parser for xlsx files

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -38,7 +38,7 @@
 -- Inside the XlsxM monad, you can stream 'SheetItem's (a row) from a
 -- particular sheet, using one of two approaches:
 -- 1) 'getSheetSource' for a conduit-based API
--- 2) 'sheetSource' for a slightly faster (~x0.65) event callback API.
+-- 2) 'readSheet' for a slightly faster (~x0.65) event callback API.
 --
 {-# LANGUAGE TypeApplications    #-}
 module Codec.Xlsx.Parser.Stream

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -135,12 +135,20 @@
 -- @
 {-# LANGUAGE TypeApplications    #-}
 module Codec.Xlsx.Parser.Stream
-  ( -- * Parsers
+  ( -- * Parser API based on "zip-stream" package
     readXlsxC
   , readXlsxWithSharedStringMapC
   , parseSharedStringsC
   , parseSharedStringsIntoMapC
-  -- * Structs
+
+  -- * Parser API based on "zip" package
+  , XlsxM
+  , runXlsxM
+  , getSheetSource
+  , getSheetXmlSource
+  , getOrParseSharedStrings
+
+  -- * Types shared by both parser approaches
   , CellRow
   , SheetItem(..)
   -- ** `SheetItem` lens
@@ -148,11 +156,13 @@ module Codec.Xlsx.Parser.Stream
   , si_row_index
   , si_cell_row
 
-  -- ** API based on 'zip' library for selective sheet reading
-  , XlsxM
-  , runXlsxM
-  , getSheetSource
-  , getOrParseSharedStrings
+  -- * Errors that either parser can throw
+  , SheetErrors(..)
+  {-- TODO: check if these errors could be exposed to users or not
+  , AddCellErrors(..)
+  , CoordinateErrors(..)
+  , TypeError(..)
+  --}
   ) where
 
 import           Codec.Archive.Zip.Conduit.UnZip

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -43,7 +43,6 @@ module Codec.Xlsx.Parser.Stream
   ( XlsxM
   , runXlsxM
   , readSheet
-  , getOrParseSharedStrings
   , countRowsInSheet
   , CellRow
   , SheetItem(..)

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -502,8 +502,10 @@ parseValue sstrings txt = \case
     Right $ CellText string
   TStr -> pure $ CellText txt
   TN -> bimap (ReadError txt) (CellDouble . fst) $ Read.double txt
-  TB -> bimap (ReadError txt) CellBool . readEither $ Text.unpack txt
   TE -> bimap (ReadError txt) (CellError . fst) $ fromAttrVal txt
+  TB | txt == "1" -> Right $ CellBool True
+     | txt == "0" -> Right $ CellBool False
+     | otherwise -> Left $ ReadError txt "Could not read Excel boolean value (expected 0 or 1)"
   Untyped -> Right (parseUntypedValue txt)
 
 -- TODO: some of the cells are untyped and we need to test whether
@@ -599,7 +601,7 @@ parseType list =
         "n"   -> Right TN
         "s"   -> Right TS
         "str" -> Right TStr
-        "b"   -> Right TS -- For some reason bools are also indexed
+        "b"   -> Right TB
         "e"   -> Right TE
         other -> Left $ UnkownType other list
 

--- a/src/Codec/Xlsx/Parser/Stream/HexpatInternal.hs
+++ b/src/Codec/Xlsx/Parser/Stream/HexpatInternal.hs
@@ -1,0 +1,94 @@
+{-
+Under BSD 3-Clause license, (c) 2009 Doug Beardsley <mightybyte@gmail.com>, (c) 2009-2012 Stephen Blackheath <http://blacksapphire.com/antispam/>, (c) 2009 Gregory Collins, (c) 2008 Evan Martin <martine@danga.com>, (c) 2009 Matthew Pocock <matthew.pocock@ncl.ac.uk>, (c) 2007-2009 Galois Inc., (c) 2010 Kevin Jardine, (c) 2012 Simon Hengel
+
+From https://hackage.haskell.org/package/hexpat-0.20.13
+-}
+module Codec.Xlsx.Parser.Stream.HexpatInternal (parseBuf) where
+
+import Control.Monad
+import Text.XML.Expat.SAX
+import Text.XML.Expat.Internal.IO
+import qualified Data.ByteString.Internal as I
+import Data.Bits
+import Data.Int
+import Data.ByteString.Internal (c2w, w2c, c_strlen)
+import Data.Word
+import Foreign.C
+import Foreign.ForeignPtr
+import Foreign.Marshal.Array
+import Foreign.Ptr
+import Foreign.Storable
+
+{-# SCC parseBuf #-}
+parseBuf :: (GenericXMLString tag, GenericXMLString text) =>
+            ForeignPtr Word8 -> CInt -> (Ptr Word8 -> Int -> IO (a, Int)) -> IO [(SAXEvent tag text, a)]
+parseBuf buf _ processExtra = withForeignPtr buf $ \pBuf -> doit [] pBuf 0
+  where
+    roundUp32 offset = (offset + 3) .&. complement 3
+    doit acc pBuf offset0 = offset0 `seq` do
+        typ <- peek (pBuf `plusPtr` offset0 :: Ptr Word32)
+        (a, offset) <- processExtra pBuf (offset0 + 4)
+        case typ of
+            0 -> return (reverse acc)
+            1 -> do
+                nAtts <- peek (pBuf `plusPtr` offset :: Ptr Word32)
+                let pName = pBuf `plusPtr` (offset + 4)
+                lName <- fromIntegral <$> c_strlen pName
+                let name = gxFromByteString $ I.fromForeignPtr buf (offset + 4) lName
+                (atts, offset') <- foldM (\(atts, offset) _ -> do
+                        let pAtt = pBuf `plusPtr` offset
+                        lAtt <- fromIntegral <$> c_strlen pAtt
+                        let att = gxFromByteString $ I.fromForeignPtr buf offset lAtt
+                            offset' = offset + lAtt + 1
+                            pValue = pBuf `plusPtr` offset'
+                        lValue <- fromIntegral <$> c_strlen pValue
+                        let value = gxFromByteString $ I.fromForeignPtr buf offset' lValue
+                        return ((att, value):atts, offset' + lValue + 1)
+                    ) ([], offset + 4 + lName + 1) [1,3..nAtts]
+                doit ((StartElement name (reverse atts), a) : acc) pBuf (roundUp32 offset')
+            2 -> do
+                let pName = pBuf `plusPtr` offset
+                lName <- fromIntegral <$> c_strlen pName
+                let name = gxFromByteString $ I.fromForeignPtr buf offset lName
+                    offset' = offset + lName + 1
+                doit ((EndElement name, a) : acc) pBuf (roundUp32 offset')
+            3 -> do
+                len <- fromIntegral <$> peek (pBuf `plusPtr` offset :: Ptr Word32)
+                let text = gxFromByteString $ I.fromForeignPtr buf (offset + 4) len
+                    offset' = offset + 4 + len
+                doit ((CharacterData text, a) : acc) pBuf (roundUp32 offset')
+            4 -> do
+                let pEnc = pBuf `plusPtr` offset
+                lEnc <- fromIntegral <$> c_strlen pEnc
+                let enc = gxFromByteString $ I.fromForeignPtr buf offset lEnc
+                    offset' = offset + lEnc + 1
+                    pVer = pBuf `plusPtr` offset'
+                pVerFirst <- peek (castPtr pVer :: Ptr Word8)
+                (mVer, offset'') <- case pVerFirst of
+                    0 -> return (Nothing, offset' + 1)
+                    1 -> do
+                        lVer <- fromIntegral <$> c_strlen (pVer `plusPtr` 1)
+                        return (Just $ gxFromByteString $ I.fromForeignPtr buf (offset' + 1) lVer, offset' + 1 + lVer + 1)
+                    _ -> error "hexpat: bad data from C land"
+                cSta <- peek (pBuf `plusPtr` offset'' :: Ptr Int8)
+                let sta = if cSta < 0  then Nothing else
+                          if cSta == 0 then Just False else
+                                            Just True
+                doit ((XMLDeclaration enc mVer sta, a) : acc) pBuf (roundUp32 (offset'' + 1))
+            5 -> doit ((StartCData, a) : acc) pBuf offset
+            6 -> doit ((EndCData, a) : acc) pBuf offset
+            7 -> do
+                let pTarget = pBuf `plusPtr` offset
+                lTarget <- fromIntegral <$> c_strlen pTarget
+                let target = gxFromByteString $ I.fromForeignPtr buf offset lTarget
+                    offset' = offset + lTarget + 1
+                    pData = pBuf `plusPtr` offset'
+                lData <- fromIntegral <$> c_strlen pData
+                let dat = gxFromByteString $ I.fromForeignPtr buf offset' lData
+                doit ((ProcessingInstruction target dat, a) : acc) pBuf (roundUp32 (offset' + lData + 1))
+            8 -> do
+                let pText = pBuf `plusPtr` offset
+                lText <- fromIntegral <$> c_strlen pText
+                let text = gxFromByteString $ I.fromForeignPtr buf offset lText
+                doit ((Comment text, a) : acc) pBuf (roundUp32 (offset + lText + 1))
+            _ -> error "hexpat: bad data from C land"

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DeriveGeneric #-}
 -- | This module provides a function for serializing structured `Xlsx` into lazy bytestring
@@ -9,7 +10,7 @@ module Codec.Xlsx.Writer
   ( fromXlsx
   ) where
 
-import qualified Codec.Archive.Zip as Zip
+import qualified "zip-archive" Codec.Archive.Zip as Zip
 import Control.Arrow (second)
 #ifdef USE_MICROLENS
 import Lens.Micro

--- a/test/StreamTests.hs
+++ b/test/StreamTests.hs
@@ -30,6 +30,7 @@ import qualified Data.Text                                   as Text
 import           Data.Vector                                 (Vector, indexed,
                                                               toList)
 import           Diff
+import System.Directory (getTemporaryDirectory)
 import           System.FilePath.Posix
 import           Test.Tasty                                  (TestName,
                                                               TestTree,
@@ -51,15 +52,11 @@ import Control.DeepSeq
 import Data.Conduit
 import Codec.Xlsx.Formatted
 
-tempPath :: FilePath
-tempPath = "test" </> "temp"
-
 toBs = LB.toStrict . fromXlsx testTime
 
 mkTestCase :: TestName -> Xlsx -> TestTree
 mkTestCase testName xlsx = testCase testName $ do
   res <- C.runResourceT $ C.runConduit $  yield (toBs xlsx) .| parseSharedStringsIntoMapC
-
   let
     testSst :: Vector XlsxText
     testSst = sstTable $ sstConstruct (xlsx ^.. xlSheets . traversed . _2)

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -104,8 +104,9 @@ Library
                    , xml-conduit  >= 1.1.0
                    , zip-archive  >= 0.2
                    , zlib         >= 0.5.4.0
+                   , zip
                    , zip-stream   >= 0.2.0.1
-                   , xml-types   
+                   , xml-types
                    , exceptions
                    , nothunks
   if flag(microlens)
@@ -160,7 +161,7 @@ test-suite data-test
                , xlsx
                , xml-conduit >= 1.1.0
                , conduit
-               , filepath 
+               , filepath
                , deepseq
   Default-Language:     Haskell2010
 
@@ -186,7 +187,7 @@ executable streaming
   --   -fprof-auto
   --   -fprof-cafs
   --   -eventlog
-  --   -prof 
+  --   -prof
   --   "-with-rtsopts=-N -l -p -s -hT -i0.1 -K100M"
   build-depends: base
                , bytestring

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -218,6 +218,7 @@ executable streaming
   build-depends: base
                , bytestring
                , criterion
+               , dlist
                , xlsx
                , conduit
                , containers

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -182,6 +182,19 @@ benchmark bench
                , xlsx
   default-language: Haskell2010
 
+executable countrows
+  type: exitcode-stdio-1.0
+  hs-source-dirs: countrows
+  main-is: Main.hs
+--  profiling: True
+--  ghc-options: -threaded -fprof-auto -O2 -prof "-with-rtsopts=-p -s -t"
+  profiling: False
+  ghc-options: -threaded -O2
+  build-depends: base
+               , xlsx
+  default-language: Haskell2010
+
+
 executable streaming
   hs-source-dirs: benchmarks
   main-is: Stream.hs

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -82,6 +82,7 @@ Library
                    , Codec.Xlsx.Writer.Internal.Stream
 
   Build-depends:     base         >= 4.9.0.0 && < 5.0
+                   , async
                    , attoparsec
                    , base64-bytestring
                    , binary-search
@@ -113,6 +114,10 @@ Library
                    , xml-types
                    , exceptions
                    , nothunks
+                   , lifted-async
+                   , stm
+                   , transformers-base
+                   , monad-control
   if flag(microlens)
     Build-depends:     microlens    >= 0.4 && < 0.5
                      , microlens-mtl

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -105,6 +105,7 @@ Library
                    , vector       >= 0.10
                    , xeno         >= 0.3.2
                    , xml-conduit  >= 1.1.0
+                   , libxml-sax
                    , zip-archive  >= 0.2
                    , zlib         >= 0.5.4.0
                    , zip
@@ -163,6 +164,7 @@ test-suite data-test
                , vector
                , xlsx
                , xml-conduit >= 1.1.0
+               , libxml-sax
                , conduit
                , filepath
                , deepseq

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -81,6 +81,8 @@ Library
                    , Codec.Xlsx.Writer.Stream
                    , Codec.Xlsx.Writer.Internal.Stream
 
+  Other-modules:     Codec.Xlsx.Parser.Stream.HexpatInternal
+
   Build-depends:     base         >= 4.9.0.0 && < 5.0
                    , async
                    , attoparsec
@@ -193,10 +195,10 @@ executable countrows
   type: exitcode-stdio-1.0
   hs-source-dirs: countrows
   main-is: Main.hs
---  profiling: True
---  ghc-options: -threaded -fprof-auto -O2 -prof "-with-rtsopts=-p -s -t"
+  -- profiling: True
+  -- ghc-options: -rtsopts -threaded -fprof-auto -O2 -prof
   profiling: False
-  ghc-options: -threaded -O2
+  ghc-options: -rtsopts -threaded -O2
   build-depends: base
                , xlsx
   default-language: Haskell2010

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -109,7 +109,6 @@ Library
                    , vector       >= 0.10
                    , xeno         >= 0.3.2
                    , xml-conduit  >= 1.1.0
-                   , libxml-sax
                    , zip-archive  >= 0.2
                    , zlib         >= 0.5.4.0
                    , zip
@@ -172,7 +171,6 @@ test-suite data-test
                , vector
                , xlsx
                , xml-conduit >= 1.1.0
-               , libxml-sax
                , conduit
                , filepath
                , deepseq

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -145,6 +145,7 @@ test-suite data-test
                , bytestring
                , containers
                , Diff >= 0.3.0
+               , directory
                , groom
                , lens >= 3.8 && < 5.1
                , mtl

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -36,7 +36,8 @@ Flag microlens
 
 Library
   Hs-source-dirs:    src
-  ghc-options:       -Wall
+  profiling: False
+  ghc-options:       -Wall -O2
   Exposed-modules:   Codec.Xlsx
                    , Codec.Xlsx.Types
                    , Codec.Xlsx.Formatted
@@ -92,6 +93,8 @@ Library
                    , errors
                    , extra
                    , filepath
+                   , hexpat
+                   , List
                    , mtl          >= 2.1
                    , network-uri
                    , old-locale   >= 1.0.0.5

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -93,6 +93,7 @@ Library
                    , containers   >= 0.5.0.0
                    , data-default
                    , deepseq      >= 1.4
+                   , dlist
                    , errors
                    , extra
                    , filepath


### PR DESCRIPTION
Adds a new parsing method inside a custom monad, which wraps the [zip package's](https://hackage.haskell.org/package/zip) ZipArchive monad with some extra state. It means we can stream selectively from specific sheets, and load into memory smaller things like shared strings and (eventually/todo) the meta-info in `xl/workbook.xml`. I also added a `countRowsInSheet` API to show how we can run that particular count more efficiently.

Includes 2 extra fixes: 
-  [CellValue parser] boolean parsing shouldn't use the shared strings (I don't think/not in any xlsx file I've seen)
-  ["zip-stream"-based parser] state management around 'sheet name'  needed a fix to collect all cells in the row.

I'm not sure whether we would want to replace the use of `zip-stream` entirely with this `XlsxM` approach, or keep it as yet another alternative API. I'm leaning towards replacing, but wanted to get feedback and/or focus on integrating it into the main app some more first (see the private streaming-xlsx-submission branch for that ;)).

There's a fair bit of mess that should be cleaned up. I would have marked this as draft until we settled on the approach and the code was cleaned up a bit, and integrated into the main app. But it looks like we're using master as a bit of a WIP branch anyway, so I thought I'd open for merging. If you like the approach @jappeace, then we could merge sooner and do cleanup on master in a way that integrates both the reading and writing work?