### PR TITLE
Fix bug where writing of larger files got truncated to last result

### DIFF
--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,4 +1,3 @@
-with-compiler: ghc-8.8.4
 optimization: 2
 ignore-project: False
 library-profiling: False 

--- a/test/StreamTests.hs
+++ b/test/StreamTests.hs
@@ -93,6 +93,7 @@ tests =
 
       testGroup "Reader/Writer"
       [ testCase "Write as stream, see if memory based implementation can read it" $ readWrite simpleWorkbook
+      , testCase "Test a big workbook which caused issues with zipstream" $ readWrite bigWorkbook
       -- , testCase "Write as stream, see if memory based implementation can read it" $ readWrite testXlsx
       -- TODO forall SheetItem write that can be read
       ]
@@ -148,3 +149,9 @@ simpleWorkbook :: Xlsx
 simpleWorkbook = formatWorkbook sheets minimalStyleSheet
   where
     sheets = [("Sheet1" , M.fromList [((1,1), (def & formattedCell . cellValue ?~ CellText "text at A1 Sheet1"))])]
+
+bigWorkbook :: Xlsx
+bigWorkbook = formatWorkbook sheets minimalStyleSheet
+  where
+    sheets = [("Sheet1" , M.fromList $ [0..512] >>= \row ->
+                  [((row,1), (def & formattedCell . cellValue ?~ CellText "text at A1 Sheet1")), ((row,2), (def & formattedCell . cellValue ?~ CellText "text at B1 Sheet1"))])]


### PR DESCRIPTION
The way I used zipstream before only works for files up to so
many rows. This makes it always work.
I had to modify the API of 'writeXlsxWithSharedStrings'
to fix this bug.