### PR TITLE
Add row properties

### DIFF
--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -48,6 +48,10 @@ module Codec.Xlsx.Types (
     , Cell.cellStyle
     , Cell.cellComment
     , Cell.cellFormula
+    -- ** Row properties
+    , rowHeightLens
+    , _CustomHeight
+    , _AutomaticHeight
     -- * Style helpers
     , emptyStyles
     , renderStyleSheet
@@ -99,6 +103,7 @@ import Codec.Xlsx.Types.StyleSheet as X
 import Codec.Xlsx.Types.Table as X
 import Codec.Xlsx.Types.Variant as X
 import Codec.Xlsx.Writer.Internal
+import Control.Lens hiding ((.=))
 
 -- | Height of a row in points (1/72in)
 data RowHeight
@@ -108,6 +113,8 @@ data RowHeight
     -- ^ Row height is set automatically by the program
   deriving (Eq, Ord, Show, Read, Generic)
 instance NFData RowHeight
+
+makePrisms ''RowHeight
 
 -- | Properties of a row. See §18.3.1.73 "row (Row)" for more details
 data RowProperties = RowProps
@@ -119,6 +126,9 @@ data RowProperties = RowProps
     -- ^ Whether row is visible or not
   } deriving (Eq, Ord, Show, Read, Generic)
 instance NFData RowProperties
+
+rowHeightLens :: Lens' RowProperties (Maybe RowHeight)
+rowHeightLens = lens rowHeight $ \x y -> x{rowHeight=y}
 
 instance Default RowProperties where
   def = RowProps { rowHeight       = Nothing


### PR DESCRIPTION
This allows users to set rows to a particular height.

This also includes a small refactor:
The primary reason for this is to expose the reader monad
within the row.
However,
this may give a speedup as well because we're relying more
on conduit and less on (slow) list concatenation.
Furthermore it looks a lot nicer because the implementations
no longer have to manually construct the Event types and get
surounded with tags trough the callback.