### PR TITLE
Add style parsing and writing

### DIFF
--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -571,11 +571,7 @@ findName :: ByteString -> SheetValues -> Maybe SheetValue
 findName name = find ((name ==) . fst)
 {-# INLINE findName #-}
 
-setStyle ::
-  ( MonadError SheetErrors m
-     , HasSheetState m
- )
-  => SheetValues -> m ()
+setStyle :: (MonadError SheetErrors m, HasSheetState m) => SheetValues -> m ()
 setStyle list = do
   style <- liftEither $ first ParseStyleErrors $ parseStyle list
   ps_cell_style .= style


### PR DESCRIPTION
Also modifies the test to confirm this works.
The styles are fully unstructured,
which should be good enough for our usecase.
It's still possible to use the existing formatted cell
API with this because it ends up being the same
unstructured type in xlsx.