### PR TITLE
Add memoize functionality

### DIFF
--- a/src/Codec/Xlsx/Parser/Internal/Memoize.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Memoize.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | I rewrote: https://hackage.haskell.org/package/unliftio-0.2.20/docs/src/UnliftIO.Memoize.html#Memoized
+-- for monad trans basecontrol
+-- we don't need a generic `m` anyway. it's good enough in base IO.
+module Codec.Xlsx.Parser.Internal.Memoize
+  ( Memoized
+  , runMemoized
+  , memoizeRef
+  ) where
+
+import Control.Applicative as A
+import Control.Monad (join)
+import Control.Monad.IO.Class
+import Data.IORef
+import Control.Exception
+
+-- | A \"run once\" value, with results saved. Extract the value with
+-- 'runMemoized'. For single-threaded usage, you can use 'memoizeRef' to
+-- create a value. If you need guarantees that only one thread will run the
+-- action at a time, use 'memoizeMVar'.
+--
+-- Note that this type provides a 'Show' instance for convenience, but not
+-- useful information can be provided.
+--
+-- @since 0.2.8.0
+newtype Memoized a = Memoized (IO a)
+  deriving (Functor, A.Applicative, Monad)
+instance Show (Memoized a) where
+  show _ = "<<Memoized>>"
+
+-- | Extract a value from a 'Memoized', running an action if no cached value is
+-- available.
+--
+-- @since 0.2.8.0
+runMemoized :: MonadIO m => Memoized a -> m a
+runMemoized (Memoized m) = liftIO m
+{-# INLINE runMemoized #-}
+
+-- | Create a new 'Memoized' value using an 'IORef' under the surface. Note that
+-- the action may be run in multiple threads simultaneously, so this may not be
+-- thread safe (depending on the underlying action). Consider using
+-- 'memoizeMVar'.
+--
+-- @since 0.2.8.0
+memoizeRef :: IO a -> IO (Memoized a)
+memoizeRef action = do
+  ref <- newIORef Nothing
+  pure $ Memoized $ do
+    mres <- readIORef ref
+    res <-
+      case mres of
+        Just res -> pure res
+        Nothing -> do
+          res <- try @SomeException action
+          writeIORef ref $ Just res
+          pure res
+    either throwIO pure res

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -84,6 +84,7 @@ Library
   -- We could expose it but then this function is in the xlsx API for a long time.
   -- It be better to expose it in the upstream library instead I think. It was copied here so the parser can use it.
   Other-modules:     Codec.Xlsx.Parser.Stream.HexpatInternal
+                   , Codec.Xlsx.Parser.Internal.Memoize
 
   Build-depends:     base         >= 4.9.0.0 && < 5.0
                    , attoparsec


### PR DESCRIPTION
Based on the review comment of qlirka I added a memoized module.
Which cleans up reading functions such as getWorkbookRelationships
quite a bit.
This is a little slower because the zip archive gets read multiple
times.
But this seemed to have no impact on the benchmarks.

Furthermore I changed runExpat to be in IO.

The only external change is that I
Attached context to workbook errors.
But these are exceptions that weren't
exposed in the first place.

Add TODO item for bad reading of zip